### PR TITLE
Added bare compilation, amended eligibility check

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -12,8 +12,12 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      // otherwise throws command not found error
-      return true;
+      var textEditor = atom.workspace.getActiveTextEditor();
+      if (!textEditor || !textEditor.getPath()) {
+        return false;
+      }
+      var path = textEditor.getPath();
+      return path.endsWith('.coffee') || path.endsWith('.cson');
     }
 
     settings() {
@@ -30,6 +34,16 @@ export function provideBuilder() {
           sh: false,
           keymap: 'cmd-alt-b',
           atomCommandName: 'coffeescript:compile',
+          errorMatch: errorMatch
+        },
+        {
+          name: 'CoffeeScript --bare',
+          exec: 'coffee',
+          args: [ '--compile', '--bare', '{FILE_ACTIVE}' ],
+          cwd: '{FILE_ACTIVE_PATH}',
+          sh: false,
+          keymap: 'cmd-alt-shift-b',
+          atomCommandName: 'coffeescript:compile-bare',
           errorMatch: errorMatch
         },
         {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "devDependencies": {
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.4",
     "eslint": "^2.4.0",
     "eslint-config-atom-build": "^2.0.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
- Added support for the '--bare' compile option as separate build option
- Changed isEligible function to only target '.coffee' and '.cson' files
- Updated package.json to use latest version of '[babel-eslint](https://www.npmjs.com/package/babel-eslint)' due to failed dependency check on travis-ci build