### PR TITLE
Fix for isEligible

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,4 +1,6 @@
 'use babel';
+import fs from 'fs';
+import path from 'path';
 
 export function provideBuilder() {
 
@@ -12,12 +14,26 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      var textEditor = atom.workspace.getActiveTextEditor();
-      if (!textEditor || !textEditor.getPath()) {
-        return false;
+      var isThereCoffee = function(startPath) {
+        if (!fs.existsSync(startPath)) {
+          return false;
+        }
+
+        var files = fs.readdirSync(startPath);
+        for(var i = 0; i < files.length; i++) {
+          var filename = path.join(startPath, files[i]);
+          if(!filename.endsWith('node_modules') && !filename.endsWith('.git')) {
+            var stat = fs.lstatSync(filename);
+
+            if((stat.isDirectory() && isThereCoffee(filename))
+              || filename.indexOf('.coffee') >= 0) {
+              return true;
+            }
+          }
+        }
       }
-      var path = textEditor.getPath();
-      return path.endsWith('.coffee') || path.endsWith('.cson');
+
+      return isThereCoffee(this.cwd);
     }
 
     settings() {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -12,10 +12,6 @@ export function provideBuilder()  {
       this.cwd = cwd;
     }
 
-    destructor() {
-
-    }
-
     getNiceName() {
       return 'CoffeeScript';
     }
@@ -41,6 +37,13 @@ export function provideBuilder()  {
       }
 
       return isThereCoffee(this.cwd);
+    }
+
+    on(event, cb) {
+      if(event == 'refresh') {
+        atom.commands.dispatch('atom-workspace', 'build:refresh-targets');
+      }
+      this.emit(event);
     }
 
     settings() {
@@ -78,6 +81,11 @@ export function provideBuilder()  {
           keymap: 'cmd-alt-cmd-b',
           atomCommandName: 'coffeescript:compile-and-create-map',
           errorMatch: errorMatch
+        },
+        {
+          name: 'CoffeeScript --ignore',
+          exec: 'echo',
+          args: ['"File ignored, no coffee was brewed"']
         }
       ];
     }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -39,13 +39,6 @@ export function provideBuilder()  {
       return isThereCoffee(this.cwd);
     }
 
-    on(event, cb) {
-      if(event == 'refresh') {
-        atom.commands.dispatch('atom-workspace', 'build:refresh-targets');
-      }
-      this.emit(event);
-    }
-
     settings() {
       const errorMatch = [
         '(?<file>([^:]+)):(?<line>\\d+):(?<col>\\d+):(?<message>.+)\\n'

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,11 +1,14 @@
 'use babel';
 
+const self = '[build-coffeescript] ';
+const debug = atom.config.get('build-coffeescript.debug');
+
+import exec from 'child_process';
 import EventEmitter from 'events';
 import fs from 'fs';
 import path from 'path';
 
-export function provideBuilder()  {
-
+export function provideBuilder() {
   return class CoffeescriptProvider extends EventEmitter {
     constructor(cwd) {
       super();
@@ -17,6 +20,15 @@ export function provideBuilder()  {
     }
 
     isEligible() {
+      exec('coffee --version', function (error, stdout, stderr) {
+        if (error !== null) {
+          if (debug === true) console.log(self + error);
+          // No CoffeeScript installed
+          return false;
+        }
+        if (debug === true) console.log(self + stdout);
+      });
+      // Confirmed 'coffee' is installed, now check for '.coffee' or '.cson' file
       var isThereCoffee = function(startPath) {
         if (!fs.existsSync(startPath)) {
           return false;
@@ -82,5 +94,5 @@ export function provideBuilder()  {
         }
       ];
     }
-  }
+  };
 }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -26,7 +26,8 @@ export function provideBuilder() {
             var stat = fs.lstatSync(filename);
 
             if((stat.isDirectory() && isThereCoffee(filename))
-              || filename.indexOf('.coffee') >= 0) {
+              || filename.indexOf('.coffee') >= 0 
+              || filename.indexOf('.cson') >= 0) {
               return true;
             }
           }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,12 +1,19 @@
 'use babel';
+
+import EventEmitter from 'events';
 import fs from 'fs';
 import path from 'path';
 
-export function provideBuilder() {
+export function provideBuilder()  {
 
-  return class CoffeescriptProvider {
+  return class CoffeescriptProvider extends EventEmitter {
     constructor(cwd) {
+      super();
       this.cwd = cwd;
+    }
+
+    destructor() {
+
     }
 
     getNiceName() {
@@ -26,8 +33,7 @@ export function provideBuilder() {
             var stat = fs.lstatSync(filename);
 
             if((stat.isDirectory() && isThereCoffee(filename))
-              || filename.indexOf('.coffee') >= 0 
-              || filename.indexOf('.cson') >= 0) {
+              || filename.indexOf('.coffee') >= 0) {
               return true;
             }
           }


### PR DESCRIPTION
- `isEligible()` now recursively checks all directories below `cwd` for files with the `.coffee.` extension or the `.cson` extension and returns true, thereby enabling the package, if it finds such a file
- Currently this ignores the node_modules and .git directories when searching in order to ensure it is as fast as possible, feel free to add any other folders to be ignored as required, I thought these seemed most likely to occur in the largest number of projects
- Tested and successfully picks up new files added to a project with `.coffee` extension allowing the build targets to be added. 