### PR TITLE
Updated Version

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -3,10 +3,10 @@
 const self = '[build-coffeescript] ';
 const debug = atom.config.get('build-coffeescript.debug');
 
-import exec from 'child_process';
-import EventEmitter from 'events';
-import fs from 'fs';
-import path from 'path';
+import {exec} from 'child_process';
+import {EventEmitter} from 'events';
+import {fs} from 'fs';
+import {path} from 'path';
 
 export function provideBuilder() {
   return class CoffeescriptProvider extends EventEmitter {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -4,9 +4,9 @@ const self = '[build-coffeescript] ';
 const debug = atom.config.get('build-coffeescript.debug');
 
 import {exec} from 'child_process';
-import {EventEmitter} from 'events';
-import {fs} from 'fs';
-import {path} from 'path';
+import EventEmitter from 'events';
+import fs from 'fs';
+import path from 'path';
 
 export function provideBuilder() {
   return class CoffeescriptProvider extends EventEmitter {


### PR DESCRIPTION
- Rebased to v0.2.3
- Provider now extends Node class EventEmitter in order for build targets to be refreshed upon new files being added to the project, relevant imports added and constructor amended accordingly
- Recursive checking added to check for the presence of `.coffee` or `.cson` files in the project, combined with the check to ensure `coffee` is installed, this should ensure build targets are only presented when actually required and able to run
- Dummy build target added to avoid problem whereby the build tries to run on all files on save, irrespective of whether they are valid `.coffee` or `.cson` files
  - Ideally this should be replaced by logic to check this before running the build target command, but I'm unsure on how to proceed with this
  - Build targets are added upon a new `.coffee` or `.cson` file being added and saved to the project, unsure of how to remove them when all such files are deleted, the dummy build target is a workaround for this